### PR TITLE
Catch exceptions which are thrown by method 'get' in method 'getStoryBySlug'

### DIFF
--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -266,7 +266,11 @@ class Client
                 'version' => $version
             );
 
-            $response = $this->get($key, $options);
+            try {
+                $response = $this->get($key, $options);
+            } catch (\Exception $e) {
+                throw $e;
+            }
 
             $this->responseBody = $response->httpResponseBody;
 


### PR DESCRIPTION
Catch exceptions which are thrown by method 'get' in method 'getStoryBySlug' so that the user of 'getStoryBySlug' is able to catch exceptions and do her/his own exception handling