### PR TITLE
Added new method getStoryByUuid

### DIFF
--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -326,7 +326,7 @@ class Client
 
     /**
      * Gets cache version from cache or as timestamp
-     * 
+     *
      * @return Integer
      */
     function getCacheVersion()
@@ -348,49 +348,80 @@ class Client
      */
     public function getStoryBySlug($slug)
     {
-        $version = 'published';
-
-        if ($this->editModeEnabled) {
-            $version = 'draft';
-        }
-
-        $key = 'stories/' . $slug;
-        $cachekey = $this->_getCacheKey($key);
-
-        $this->reCacheOnPublish($key);
-
-        if ($version == 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
-            if ($this->cacheNotFound && $cachedItem->httpResponseCode == 404) {
-                throw new \Exception(self::EXCEPTION_GENERIC_HTTP_ERROR, 404);
-            }
-
-            $this->_assignState($cachedItem);
-        } else {
-            $options = array(
-                'token' => $this->apiKey,
-                'version' => $version,
-                'cache_version' => $this->getCacheVersion()
-            );
-
-            try {
-                $response = $this->get($key, $options);
-                $this->_save($response, $cachekey, $version);
-            } catch (\Exception $e) {
-                if ($this->cacheNotFound && $e->getCode() === 404) {
-                    $result = new \stdClass();
-                    $result->httpResponseBody = [];
-                    $result->httpResponseCode = 404;
-                    $result->httpResponseHeaders = [];
-
-                    $this->cache->save($result, $cachekey);
-                }
-
-                throw new \Exception(self::EXCEPTION_GENERIC_HTTP_ERROR . ' - ' . $e->getMessage(), $e->getCode());
-            }
-        }
-
-        return $this;
+        return $this->getStory($slug);
     }
+
+	/**
+	 * Gets a story by it’s UUID
+	 *
+	 * @param string $uuid UUID
+	 *
+	 * @return Client
+	 * @throws \Exception
+	 */
+    public function getStoryByUuid($uuid)
+    {
+        return $this->getStory($uuid, true);
+    }
+
+	/**
+	 * Gets a story
+	 *
+	 * @param  string $slug Slug
+	 * @param bool $byUuid
+	 *
+	 * @return Client
+	 * @throws \Exception
+	 */
+	private function getStory($slug, $byUuid = false)
+	{
+		$version = 'published';
+
+		if ($this->editModeEnabled) {
+			$version = 'draft';
+		}
+
+		$key = 'stories/' . $slug;
+		$cachekey = $this->_getCacheKey($key);
+
+		$this->reCacheOnPublish($key);
+
+		if ($version == 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
+			if ($this->cacheNotFound && $cachedItem->httpResponseCode == 404) {
+				throw new \Exception(self::EXCEPTION_GENERIC_HTTP_ERROR, 404);
+			}
+
+			$this->_assignState($cachedItem);
+		} else {
+			$options = array(
+				'token' => $this->apiKey,
+				'version' => $version,
+				'cache_version' => $this->getCacheVersion()
+			);
+
+			if ($byUuid) {
+				$options['find_by'] = 'uuid';
+			}
+
+			try {
+				$response = $this->get($key, $options);
+				$this->_save($response, $cachekey, $version);
+			} catch (\Exception $e) {
+				if ($this->cacheNotFound && $e->getCode() === 404) {
+					$result = new \stdClass();
+					$result->httpResponseBody = [];
+					$result->httpResponseCode = 404;
+					$result->httpResponseHeaders = [];
+
+					$this->cache->save($result, $cachekey);
+				}
+
+				throw new \Exception(self::EXCEPTION_GENERIC_HTTP_ERROR . ' - ' . $e->getMessage(), $e->getCode());
+			}
+		}
+
+		return $this;
+	}
 
     /**
      * Gets a list of stories


### PR DESCRIPTION
When using multi-option blocks the API returns a list of linked UUIDs but these can’t be requested using the php client as it currently stands. I’ve added a getStoryByUuid method to resolve this and updated the getStoryBySlug to share the common functionality.