### PR TITLE
Allow setting timeout and maximum retries in BaseClient

### DIFF
--- a/src/Storyblok/BaseClient.php
+++ b/src/Storyblok/BaseClient.php
@@ -38,6 +38,11 @@ class BaseClient
     private $apiKey;
 
     /**
+     * @var integer
+     */
+    protected $maxRetries = 5;
+
+    /**
      * @var Guzzle
      */
     protected $client;
@@ -78,8 +83,8 @@ class BaseClient
             $response = null,
             RequestException $exception = null
         ) {
-            // Limit the number of retries to 5
-            if ($retries >= 5) {
+            // Limit the number of retries
+            if ($retries >= $this->maxRetries) {
                 return false;
             }
 
@@ -119,6 +124,16 @@ class BaseClient
     public function getApiKey()
     {
         return $this->apiKey;
+    }
+
+    /**
+     * @param $maxRetries
+     * @return BaseClient
+     */
+    public function setMaxRetries($maxRetries)
+    {
+        $this->maxRetries = $maxRetries;
+        return $this;
     }
 
     /**

--- a/src/Storyblok/BaseClient.php
+++ b/src/Storyblok/BaseClient.php
@@ -48,6 +48,11 @@ class BaseClient
     protected $proxy;
 
     /**
+     * @var float
+     */
+    protected $timeout;
+
+    /**
      * @param string $apiKey
      * @param string $apiEndpoint
      * @param string $apiVersion
@@ -132,6 +137,26 @@ class BaseClient
     }
 
     /**
+     * set timeout in seconds
+     *
+     * @param float $timeout
+     * @return BaseClient
+     */
+    public function setTimeout($timeout)
+    {
+        $this->timeout = $timeout;
+        return $this;
+    }
+
+    /**
+     * @return float
+     */
+    public function getTimeout()
+    {
+        return $this->timeout;
+    }
+
+    /**
      * @param string $apiEndpoint
      * @param string $apiVersion
      * @param bool   $ssl
@@ -172,6 +197,10 @@ class BaseClient
 
             if ($this->getProxy()) {
                 $requestOptions[RequestOptions::PROXY] = $this->getProxy();
+            }
+
+            if ($this->getTimeout()) {
+                $requestOptions[RequestOptions::TIMEOUT] = $this->getTimeout();
             }
 
             if ($this instanceof ManagementClient) {


### PR DESCRIPTION
Sometimes it is necessary to limit the time of the API request to a maximum time. This can be achieved by setting a timeout and/or overriding the default retries of 5.