### PR TITLE
guzzle dependency now supports v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "minimum-stability": "dev",
     "require": {
-        "guzzlehttp/guzzle": "^6.2",
+        "guzzlehttp/guzzle": "^6.2|^7.0",
         "apix/cache": "^1.2"
     },
     "authors": [


### PR DESCRIPTION
Compared with Guzzle's upgrade notes, the codebase seems fine.