### PR TITLE
fix: update retryDecider to use TransferException

### DIFF
--- a/src/Storyblok/BaseClient.php
+++ b/src/Storyblok/BaseClient.php
@@ -5,7 +5,7 @@ namespace Storyblok;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -81,7 +81,7 @@ class BaseClient
             $retries,
             $request,
             $response = null,
-            RequestException $exception = null
+            TransferException $exception = null
         ) {
             // Limit the number of retries
             if ($retries >= $this->maxRetries) {


### PR DESCRIPTION
As of Guzzle 7.0.0, `ConnectException` was moved under `TransferException` from `RequestException`. Guzzle docs to not properly reflect this.

Guzzle change: https://github.com/guzzle/guzzle/pull/2541

In the case of a ConnectException being thrown, this would cause another exception.

![image](https://user-images.githubusercontent.com/4369463/110969014-32d8d880-8326-11eb-95f1-9658c6847642.png)

After change (forced timeout):

![image](https://user-images.githubusercontent.com/4369463/110969592-daeea180-8326-11eb-8775-875496e58cd2.png)

