### PR TITLE
querystring regex for supporting []

### DIFF
--- a/src/Storyblok/BaseClient.php
+++ b/src/Storyblok/BaseClient.php
@@ -208,6 +208,7 @@ class BaseClient
         try {
             $query = http_build_query($queryString, null, '&');
             $string = preg_replace('/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', $query);
+            $string = preg_replace('/%5B__or%5D%5B\d+%5D%/', '%5B__or%5D%5B%5D%', $string);
             $requestOptions = [RequestOptions::QUERY => $string];
 
             if ($this->getProxy()) {


### PR DESCRIPTION
This PR adds support for the `filter_query_v2[__or][][field][operator]=` type of query documented [here](https://github.com/storyblok/storyblok/issues/94#issuecomment-618463685). The new regex is replacing any `[__or][number]` in the querystring with `[__or][]`. I think it's safe to do as nobody can name a field `__or` so it won't break any existing situation.

### How to test this
Here is an example of query that you can use:
```
$client->getStories(['filter_query_v2' => ["__or" => [
	["fieldname" => ["in" => "value1"]], 
	["fieldname" => ["in" => "value2"]]
]]]);
```