### PR TITLE
Feature/api v2

### DIFF
--- a/src/Storyblok/BaseClient.php
+++ b/src/Storyblok/BaseClient.php
@@ -465,11 +465,9 @@ class BaseClient
     
     /**
      * Insert the resolved links in a story
-     * @param string $component
-     * @param string $field
-     * @param string|array $value
+     * @param \stdClass $node
      *
-     * @return null
+     * @return \stdClass
      */
     private function insertLinks($node) {
         $filteredNode = $node;

--- a/src/Storyblok/BaseClient.php
+++ b/src/Storyblok/BaseClient.php
@@ -63,7 +63,7 @@ class BaseClient
      * @param string $apiVersion
      * @param bool   $ssl
      */
-    function __construct($apiKey = null, $apiEndpoint = "api.storyblok.com", $apiVersion = "v1", $ssl = false)
+    function __construct($apiKey = null, $apiEndpoint = "api.storyblok.com", $apiVersion = "v2", $ssl = false)
     {
         $handlerStack = HandlerStack::create(new CurlHandler());
         $handlerStack->push(Middleware::retry($this->retryDecider(), $this->retryDelay()));
@@ -222,10 +222,9 @@ class BaseClient
             if ($this instanceof ManagementClient) {
                 $requestOptions[RequestOptions::HEADERS] = ['Authorization' => $this->apiKey];
             }
-
             $responseObj = $this->client->request('GET', $endpointUrl, $requestOptions);
 
-            return $this->responseHandler($responseObj);
+            return $this->responseHandler($responseObj, $queryString);
         } catch (\GuzzleHttp\Exception\ClientException $e) {
             throw new ApiException(self::EXCEPTION_GENERIC_HTTP_ERROR . ' - ' . $e->getMessage(), $e->getCode());
         }
@@ -236,7 +235,7 @@ class BaseClient
      *
      * @return \stdClass
      */
-    public function responseHandler($responseObj)
+    public function responseHandler($responseObj, $queryString = [])
     {
         $httpResponseCode = $responseObj->getStatusCode();
         $data = (string) $responseObj->getBody();
@@ -247,6 +246,9 @@ class BaseClient
         $result->httpResponseBody = $data && empty($jsonResponseData) ? $data : $jsonResponseData;
         $result->httpResponseCode = $httpResponseCode;
         $result->httpResponseHeaders = $responseObj->getHeaders();
+        if (is_array($result->httpResponseBody) && isset($result->httpResponseBody['story']) || isset($result->httpResponseBody['stories'])) {
+            $result->httpResponseBody = $this->enrichStories($result->httpResponseBody, $queryString);
+        }
         return $result;
     }
 
@@ -301,5 +303,145 @@ class BaseClient
     public function getCode()
     {
         return $this->responseCode;
+    }
+
+    private function enrichStories($data, $queryString) {
+        $enrichedData = $data;
+        $this->getResolvedRelations($data, $queryString);
+        $this->getResolveLinks($data, $queryString);
+        
+        if(isset($data['story'])) {
+            $enrichedData['story']['content'] = $this->enrichContent($data['story']['content']);
+        } else if(isset($data['stories'])) {
+            $stories = [];
+            foreach($data['stories'] as $index => $story) {
+                $story = $data['stories'][$index];
+                $story['content'] = $this->enrichContent($story['content']);
+                $stories[] = $story;
+            }
+            $enrichedData['stories'] = $stories;
+        }
+        return $enrichedData;
+    }
+
+    function enrichContent($data) {
+        $enrichedContent = $data;
+        if (empty($data)) {
+            return '';
+        }
+
+        if (is_array($data) && isset($data['component'])) {
+            if(!isset($story['_stopResolving'])) {
+                foreach($data as $fieldName => $fieldValue) {
+                    $enrichedContent[$fieldName] = $this->insertRelations($data['component'], $fieldName, $fieldValue);
+                    $enrichedContent[$fieldName] = $this->insertLinks($enrichedContent[$fieldName]);
+                    $enrichedContent[$fieldName] = $this->enrichContent($enrichedContent[$fieldName]);
+                }        
+            }
+        } else if (is_array($data)) {
+            foreach($data as $key => $value) {
+                $enrichedContent[$key] = $this->enrichContent($value);
+            }
+        }
+
+        return $enrichedContent;
+    }
+
+    function getResolvedRelations($data, $queryString) {
+        $this->resolvedRelations = [];
+        $relations = [];
+
+        if(isset($data['rels'])) {
+            $relations = $data['rels'];
+        } else if(isset($data['rel_uuids'])) {
+            $relSize = count($data['rel_uuids']);
+            $chunks = [];
+            $chunkSize = 50;
+      
+            for ($i = 0; $i < $relSize; $i += $chunkSize) {
+              $end = min($relSize, $i + $chunkSize);
+              $chunks[] = array_slice($data['rel_uuids'], $i, $end);
+            }
+      
+            for ($chunkIndex = 0; $chunkIndex < count($chunks); $chunkIndex++) {
+                $relationsRes = $this->getStories(array(
+                  'per_page' => $chunkSize,
+                  'language' => isset($queryString['language']) ? $queryString['language'] : 'default',
+                  'by_uuids' => implode(',', $chunks[$chunkIndex])
+                ));
+                
+                $relations = array_merge($relations, $relationsRes->responseBody['stories']);
+            }
+        }
+
+        foreach($relations as $rel) {
+            $this->resolvedRelations[$rel['uuid']] = $rel;    
+        }
+    }
+
+    function getResolveLinks($data) {
+        $this->resolvedLinks = [];
+        $links = [];
+
+        if(isset($data['links'])) {
+            $links = $data['links'];
+        } else if(isset($data['link_uuids'])) {
+            $linksSize = count($data['link_uuids']);
+            $chunks = [];
+            $chunkSize = 50;
+      
+            for ($i = 0; $i < $linksSize; $i += $chunkSize) {
+              $end = min($linksSize, $i + $chunkSize);
+              $chunks[] = array_slice($data['link_uuids'], $i, $end);
+            }
+      
+            for ($chunkIndex = 0; $chunkIndex < count($chunks); $chunkIndex++) {
+                $linksRes = $this->getStories(array(
+                  'per_page' => $chunkSize,
+                  'language' => isset($queryString['language']) ? $queryString['language'] : 'default',
+                  'by_uuids' => implode(',', $chunks[$chunkIndex])
+                ));
+                
+                $links = array_merge($links, $linksRes->responseBody['stories']);
+            }
+        }
+
+        foreach($data['links'] as $link) {
+            $this->resolvedLinks[$link['uuid']] = $link;    
+        }
+    }
+    
+    private function insertRelations($component, $field, $value) {
+        $filteredNode = $value;
+        if(isset($this->_relationsList[$component]) && $field == $this->_relationsList[$component]) {
+            if(is_string($value)) {
+                if(isset($this->resolvedRelations[$value])) {
+                    $filteredNode = $this->resolvedRelations[$value];
+                    $filteredNode['_stopResolving'] = true;
+                }
+            } else if(is_array($value)) {
+                $filteredNode = [];
+                foreach($value as $item) {
+                    if(isset($this->resolvedRelations[$item])) {
+                        $story = $this->resolvedRelations[$item];
+                        $story['_stopResolving'] = true;
+                        $filteredNode[] = $story;
+                    }
+                }
+            }
+        }
+        return $filteredNode;
+    }
+    
+    private function insertLinks($node) {
+        $filteredNode = $node;
+        if(isset($node['fieldtype']) && $node['fieldtype'] == 'multilink' && $node['linktype'] == 'story') {
+            if(isset($node['id']) && is_string($node['id']) && isset($this->resolvedLinks[$node['id']])) {
+                $filteredNode['story'] = $this->resolvedLinks[$node['id']];
+            } else if(isset($node['uuid']) && is_string($node['uuid']) && isset($this->resolvedLinks[$node['uuid']])) {
+                $filteredNode['story'] = $this->resolvedLinks[$node['uuid']];
+            }
+        }
+        return $filteredNode;
     }
 }

--- a/src/Storyblok/BaseClient.php
+++ b/src/Storyblok/BaseClient.php
@@ -232,10 +232,11 @@ class BaseClient
 
     /**
      * @param \Psr\Http\Message\ResponseInterface $responseObj
+     * @param array $queryString
      *
      * @return \stdClass
      */
-    public function responseHandler($responseObj, $queryString = [])
+    public function responseHandler($responseObj, $queryString = array())
     {
         $httpResponseCode = $responseObj->getStatusCode();
         $data = (string) $responseObj->getBody();
@@ -325,6 +326,12 @@ class BaseClient
         return $enrichedData;
     }
 
+    /**
+     * Enrich the Stories with resolved links and stories
+     * @param \stdClass
+     *
+     * @return \stdClass
+     */
     function enrichContent($data) {
         $enrichedContent = $data;
         if (empty($data)) {
@@ -348,6 +355,13 @@ class BaseClient
         return $enrichedContent;
     }
 
+    /**
+     * Retrieve or resolve the relations
+     * @param \stdClass $data
+     * @param array $queryString 
+     *
+     * @return null
+     */
     function getResolvedRelations($data, $queryString) {
         $this->resolvedRelations = [];
         $relations = [];
@@ -380,6 +394,14 @@ class BaseClient
         }
     }
 
+
+    /**
+     * Retrieve or resolve the Links
+     * @param \stdClass $data
+     * @param array $queryString 
+     *
+     * @return null
+     */
     function getResolvedLinks($data) {
         $this->resolvedLinks = [];
         $links = [];
@@ -411,6 +433,14 @@ class BaseClient
         }
     }
     
+    /**
+     * Insert the resolved relations in a story
+     * @param string $component
+     * @param string $field
+     * @param string|array $value
+     *
+     * @return null
+     */
     private function insertRelations($component, $field, $value) {
         $filteredNode = $value;
         if(isset($this->_relationsList[$component]) && $field == $this->_relationsList[$component]) {
@@ -433,6 +463,14 @@ class BaseClient
         return $filteredNode;
     }
     
+    /**
+     * Insert the resolved links in a story
+     * @param string $component
+     * @param string $field
+     * @param string|array $value
+     *
+     * @return null
+     */
     private function insertLinks($node) {
         $filteredNode = $node;
         if(isset($node['fieldtype']) && $node['fieldtype'] == 'multilink' && $node['linktype'] == 'story') {

--- a/src/Storyblok/BaseClient.php
+++ b/src/Storyblok/BaseClient.php
@@ -246,6 +246,7 @@ class BaseClient
         $result->httpResponseBody = $data && empty($jsonResponseData) ? $data : $jsonResponseData;
         $result->httpResponseCode = $httpResponseCode;
         $result->httpResponseHeaders = $responseObj->getHeaders();
+
         if (is_array($result->httpResponseBody) && isset($result->httpResponseBody['story']) || isset($result->httpResponseBody['stories'])) {
             $result->httpResponseBody = $this->enrichStories($result->httpResponseBody, $queryString);
         }
@@ -308,7 +309,7 @@ class BaseClient
     private function enrichStories($data, $queryString) {
         $enrichedData = $data;
         $this->getResolvedRelations($data, $queryString);
-        $this->getResolveLinks($data, $queryString);
+        $this->getResolvedLinks($data, $queryString);
         
         if(isset($data['story'])) {
             $enrichedData['story']['content'] = $this->enrichContent($data['story']['content']);
@@ -379,7 +380,7 @@ class BaseClient
         }
     }
 
-    function getResolveLinks($data) {
+    function getResolvedLinks($data) {
         $this->resolvedLinks = [];
         $links = [];
 
@@ -405,8 +406,7 @@ class BaseClient
                 $links = array_merge($links, $linksRes->responseBody['stories']);
             }
         }
-
-        foreach($data['links'] as $link) {
+        foreach($links as $link) {
             $this->resolvedLinks[$link['uuid']] = $link;    
         }
     }
@@ -422,7 +422,7 @@ class BaseClient
             } else if(is_array($value)) {
                 $filteredNode = [];
                 foreach($value as $item) {
-                    if(isset($this->resolvedRelations[$item])) {
+                    if(is_string($item) && isset($this->resolvedRelations[$item])) {
                         $story = $this->resolvedRelations[$item];
                         $story['_stopResolving'] = true;
                         $filteredNode[] = $story;

--- a/src/Storyblok/BaseClient.php
+++ b/src/Storyblok/BaseClient.php
@@ -379,11 +379,14 @@ class BaseClient
             }
       
             for ($chunkIndex = 0; $chunkIndex < count($chunks); $chunkIndex++) {
-                $relationsRes = $this->getStories(array(
-                  'per_page' => $chunkSize,
-                  'language' => isset($queryString['language']) ? $queryString['language'] : 'default',
-                  'by_uuids' => implode(',', $chunks[$chunkIndex])
-                ));
+                $relationsParams = array(
+                    'per_page' => $chunkSize,
+                    'by_uuids' => implode(',', $chunks[$chunkIndex])
+                )
+                if(isset($queryString['language'])) {
+                    $relationsParams['language'] = $queryString['language'];
+                }
+                $relationsRes = $this->getStories($relationsParams);
                 
                 $relations = array_merge($relations, $relationsRes->responseBody['stories']);
             }

--- a/src/Storyblok/BaseClient.php
+++ b/src/Storyblok/BaseClient.php
@@ -382,7 +382,7 @@ class BaseClient
                 $relationsParams = array(
                     'per_page' => $chunkSize,
                     'by_uuids' => implode(',', $chunks[$chunkIndex])
-                )
+                );
                 if(isset($queryString['language'])) {
                     $relationsParams['language'] = $queryString['language'];
                 }

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -161,6 +161,7 @@ class Client extends BaseClient
         }
 
         $this->cv = $this->cache->load(self::CACHE_VERSION_KEY);
+        echo 'CV' . $this->cv;
 
         if (!$this->cv) {
             $this->setCacheVersion();
@@ -232,9 +233,9 @@ class Client extends BaseClient
     public function setCacheVersion()
     {
         if ($this->cache) {
-            $timestamp = time();
-            $this->cache->save($timestamp, self::CACHE_VERSION_KEY);
-            $this->cv = $timestamp;
+            $res = $this->getStories(Array('per_page' => 1, 'version' => $this->getVersion()));
+            $this->cv = $res->responseBody['cv'];
+            $this->cache->save($this->cv, self::CACHE_VERSION_KEY);
         }
 
         return $this;

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -248,7 +248,7 @@ class Client extends BaseClient
     function getCacheVersion()
     {
         if (empty($this->cv)) {
-            return time();
+            return '';
         }
 
         return $this->cv;

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -161,7 +161,6 @@ class Client extends BaseClient
         }
 
         $this->cv = $this->cache->load(self::CACHE_VERSION_KEY);
-        echo 'CV' . $this->cv;
 
         if (!$this->cv) {
             $this->setCacheVersion();
@@ -233,7 +232,7 @@ class Client extends BaseClient
     public function setCacheVersion()
     {
         if ($this->cache) {
-            $res = $this->getStories(Array('per_page' => 1, 'version' => $this->getVersion()));
+            $res = $this->getStories(Array('per_page' => 1, 'version' => 'published'));
             $this->cv = $res->responseBody['cv'];
             $this->cache->save($this->cv, self::CACHE_VERSION_KEY);
         }

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -97,17 +97,25 @@ class Client extends BaseClient
     }
 
     /**
+     * Returns the requested version of the content
+     *
+     * @return String
+     */
+    public function getVersion()
+    {   
+        return $this->editModeEnabled ? 'draft' : 'published';
+    }
+
+    /**
      * Returns the commond API parameters
      *
      * @return Array
      */
     public function getApiParameters()
     {
-        $version = $this->editModeEnabled ? 'draft' : 'published';
-
         return array(
             'token' => $this->getApiKey(),
-            'version' => $version,
+            'version' => $this->getVersion(),
             'cv' => $this->getCacheVersion()
         );
     }
@@ -295,18 +303,12 @@ class Client extends BaseClient
      */
     private function getStory($slug, $byUuid = false)
     {
-        $version = 'published';
-
-        if ($this->editModeEnabled) {
-            $version = 'draft';
-        }
-
         $key = 'stories/' . $slug;
         $cachekey = $this->_getCacheKey($key);
 
         $this->reCacheOnPublish($key);
 
-        if ($version === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
+        if ($this->getVersion() === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
             if ($this->cacheNotFound && $cachedItem->httpResponseCode == 404) {
                 throw new ApiException(self::EXCEPTION_GENERIC_HTTP_ERROR, 404);
             }
@@ -333,7 +335,7 @@ class Client extends BaseClient
             
             try {
                 $response = $this->get($key, $options);
-                $this->_save($response, $cachekey, $version);
+                $this->_save($response, $cachekey, $this->getVersion());
             } catch (\Exception $e) {
                 if ($this->cacheNotFound && $e->getCode() === 404) {
                     $result = new \stdClass();
@@ -368,19 +370,14 @@ class Client extends BaseClient
      */
     public function getStories($options = array())
     {
-        $version = 'published';
         $endpointUrl = 'stories/';
-
-        if ($this->editModeEnabled) {
-            $version = 'draft';
-        }
 
         $key = 'stories/' . serialize($this->_prepareOptionsForKey($options));
         $cachekey = $this->_getCacheKey($key);
 
         $this->reCacheOnPublish($key);
 
-        if ($version === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
+        if ($this->getVersion() === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
             $this->_assignState($cachedItem);
         } else {
             $options = array_merge($options, $this->getApiParameters());
@@ -395,7 +392,7 @@ class Client extends BaseClient
 
             $response = $this->get($endpointUrl, $options);
 
-            $this->_save($response, $cachekey, $version);
+            $this->_save($response, $cachekey, $this->getVersion());
         }
 
         return $this;
@@ -446,26 +443,21 @@ class Client extends BaseClient
      */
     public function getTags($options = array())
     {
-        $version = 'published';
         $endpointUrl = 'tags/';
-
-        if ($this->editModeEnabled) {
-            $version = 'draft';
-        }
 
         $key = 'tags/' . serialize($options);
         $cachekey = $this->_getCacheKey($key);
 
         $this->reCacheOnPublish($key);
 
-        if ($version === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
+        if ($this->getVersion() === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
             $this->_assignState($cachedItem);
         } else {
             $options = array_merge($options, $this->getApiParameters());
 
             $response = $this->get($endpointUrl, $options);
 
-            $this->_save($response, $cachekey, $version);
+            $this->_save($response, $cachekey, $this->getVersion());
         }
 
         return $this;
@@ -480,19 +472,14 @@ class Client extends BaseClient
      */
     public function getDatasourceEntries($slug, $options = array())
     {
-        $version = 'published';
         $endpointUrl = 'datasource_entries/';
-
-        if ($this->editModeEnabled) {
-            $version = 'draft';
-        }
 
         $key = 'datasource_entries/' . $slug . '/' . serialize($options);
         $cachekey = $this->_getCacheKey($key);
 
         $this->reCacheOnPublish($key);
 
-        if ($version === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
+        if ($this->getVersion() === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
             $this->_assignState($cachedItem);
         } else {
             $options = array_merge($options, 
@@ -501,7 +488,7 @@ class Client extends BaseClient
 
             $response = $this->get($endpointUrl, $options);
 
-            $this->_save($response, $cachekey, $version);
+            $this->_save($response, $cachekey, $this->getVersion());
         }
 
         return $this;
@@ -520,23 +507,17 @@ class Client extends BaseClient
      */
     public function getLinks($options = array())
     {
-        $version = 'published';
-
         $key = $this->linksPath;
         $cachekey = $this->_getCacheKey($key);
 
-        if ($this->editModeEnabled) {
-            $version = 'draft';
-        }
-
-        if ($version === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
+        if ($this->getVersion() === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
             $this->_assignState($cachedItem);
         } else {
             $options = array_merge($options, $this->getApiParameters());
 
             $response = $this->get($key, $options);
 
-            $this->_save($response, $cachekey, $version);
+            $this->_save($response, $cachekey, $this->getVersion());
         }
 
         return $this;

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -97,6 +97,22 @@ class Client extends BaseClient
     }
 
     /**
+     * Returns the commond API parameters
+     *
+     * @return Array
+     */
+    public function getApiParameters()
+    {
+        $version = $this->editModeEnabled ? 'draft' : 'published';
+
+        return array(
+            'token' => $this->getApiKey(),
+            'version' => $version,
+            'cv' => $this->getCacheVersion()
+        );
+    }
+
+    /**
      * Set cache driver and optional the cache path
      *
      * @param string $driver Driver
@@ -297,11 +313,7 @@ class Client extends BaseClient
 
             $this->_assignState($cachedItem);
         } else {
-            $options = array(
-                'token' => $this->getApiKey(),
-                'version' => $version,
-                'cv' => $this->getCacheVersion()
-            );
+            $options = $this->getApiParameters();
 
             if ($byUuid) {
                 $options['find_by'] = 'uuid';
@@ -371,11 +383,7 @@ class Client extends BaseClient
         if ($version === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
             $this->_assignState($cachedItem);
         } else {
-            $options = array_merge($options, array(
-                'token' => $this->getApiKey(),
-                'version' => $version,
-                'cv' => $this->getCacheVersion()
-            ));
+            $options = array_merge($options, $this->getApiParameters());
 
             if ($this->resolveRelations) {
                 $options['resolve_relations'] = $this->resolveRelations;
@@ -453,11 +461,7 @@ class Client extends BaseClient
         if ($version === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
             $this->_assignState($cachedItem);
         } else {
-            $options = array_merge($options, array(
-                'token' => $this->getApiKey(),
-                'version' => $version,
-                'cv' => $this->getCacheVersion()
-            ));
+            $options = array_merge($options, $this->getApiParameters());
 
             $response = $this->get($endpointUrl, $options);
 
@@ -491,12 +495,9 @@ class Client extends BaseClient
         if ($version === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
             $this->_assignState($cachedItem);
         } else {
-            $options = array_merge($options, array(
-                'token' => $this->getApiKey(),
-                'version' => $version,
-                'cv' => $this->getCacheVersion(),
-                'datasource' => $slug
-            ));
+            $options = array_merge($options, 
+                array('datasource' => $slug),
+                $this->getApiParameters());
 
             $response = $this->get($endpointUrl, $options);
 
@@ -531,11 +532,7 @@ class Client extends BaseClient
         if ($version === 'published' && $this->cache && $cachedItem = $this->cache->load($cachekey)) {
             $this->_assignState($cachedItem);
         } else {
-            $options = array_merge($options, array(
-                'token' => $this->getApiKey(),
-                'version' => $version,
-                'cv' => $this->getCacheVersion()
-            ));
+            $options = array_merge($options, $this->getApiParameters());
 
             $response = $this->get($key, $options);
 


### PR DESCRIPTION
This PR adds support for API V2. Features implemented are:
- the new default API version is "v2";
- the "cache_version" variable has been renamed to "cv" as the older one it'd be rejected by the API V2 because it's an unknown parameter;
- resolved relations and links are injected in the story objects in the same way as in the `storyblok-js-client`;
- in case the relations and links limits are hit, the client will perform more requests to make up for the missing stories like in the `storyblok-js-client`.
Management API is untouched as there's a separate client for that.

### How to test
You can perform requests with relations and links to resolve. Check if stories are injected into the result. 