### PR TITLE
enrichContent turning empty arrays into strings

### DIFF
--- a/src/Storyblok/BaseClient.php
+++ b/src/Storyblok/BaseClient.php
@@ -334,9 +334,6 @@ class BaseClient
      */
     function enrichContent($data) {
         $enrichedContent = $data;
-        if (empty($data)) {
-            return '';
-        }
 
         if (is_array($data) && isset($data['component'])) {
             if(!isset($story['_stopResolving'])) {


### PR DESCRIPTION
When `enrichContent()` is run on an empty array (such as a Blocks fieldtype with no items) it is transformed into a string. The empty array should be preserved as the user may be trying to loop over this content and may or may not have items causing errors when looping etc... `foreach() argument must be of type array|object, string given`; Keeping the array allows the counting of items and the appropriate response given if empty. This is also causing issues with my Laravel package.

I think it’s safe just to return the original variable at the end as it’ll only be changed if `$data` is an array. Passing the empty array doesn’t cause any issues.