### PR TITLE
Extend cache options for start using ttl param for caching

### DIFF
--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -209,7 +209,7 @@ class Client extends BaseClient
     {
         if ($this->cache) {
             $timestamp = time();
-            $this->cache->save($timestamp, self::CACHE_VERSION_KEY);
+            $this->cache->save($timestamp, self::CACHE_VERSION_KEY, null, $this->cacheTtl);
             $this->cacheVersion = $timestamp;
         }
 

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -45,6 +45,11 @@ class Client extends BaseClient
     private $cacheNotFound;
 
     /**
+     * @var int|null
+     */
+    private $cacheTtl;
+
+    /**
      * @var Cache
      */
     protected $cache;
@@ -102,6 +107,7 @@ class Client extends BaseClient
         $options['serializer'] = 'php';
         $options['prefix_key'] = 'storyblok:';
         $options['prefix_tag'] = 'storyblok:';
+        $this->cacheTtl = $options['ttl'] ?? null;
 
         switch ($driver) {
             case 'mysql':
@@ -307,7 +313,7 @@ class Client extends BaseClient
                     $result->httpResponseCode = 404;
                     $result->httpResponseHeaders = [];
 
-                    $this->cache->save($result, $cachekey);
+                    $this->cache->save($result, $cachekey, null, $this->cacheTtl);
                 }
 
                 throw new ApiException(self::EXCEPTION_GENERIC_HTTP_ERROR . ' - ' . $e->getMessage(), $e->getCode());
@@ -624,7 +630,7 @@ class Client extends BaseClient
             $response->httpResponseHeaders &&
             $response->httpResponseCode == 200) {
 
-            $this->cache->save($response, $key);
+            $this->cache->save($response, $key, null, $this->cacheTtl);
         }
     }
 


### PR DESCRIPTION
Storyblock SDK is using apix/cache.
this package gives possibility to defile TTL for cached items.

These changes extends Cache option and gives possibility to use cache expire functionality.
