### PR TITLE
fix deprecation in http_build_query

### DIFF
--- a/src/Storyblok/BaseClient.php
+++ b/src/Storyblok/BaseClient.php
@@ -206,7 +206,7 @@ class BaseClient
     public function get($endpointUrl, $queryString = array())
     {
         try {
-            $query = http_build_query($queryString, null, '&');
+            $query = http_build_query($queryString, '', '&');
             $string = preg_replace('/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', $query);
             $string = preg_replace('/%5B__or%5D%5B\d+%5D%/', '%5B__or%5D%5B%5D%', $string);
             $requestOptions = [RequestOptions::QUERY => $string];


### PR DESCRIPTION
There is a deprecation in php 8.1:

``` 
http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated
```

Using string as a default value fixes it