### PR TITLE
Feature/ssl param mapi

### DIFF
--- a/src/Storyblok/ManagementClient.php
+++ b/src/Storyblok/ManagementClient.php
@@ -20,9 +20,9 @@ class ManagementClient extends BaseClient
      * @param string $apiEndpoint
      * @param string $apiVersion
      */
-    function __construct($apiKey = null, $apiEndpoint = "mapi.storyblok.com", $apiVersion = "v1")
+    function __construct($apiKey = null, $apiEndpoint = "mapi.storyblok.com", $apiVersion = "v1", $ssl = false)
     {
-    	parent::__construct($apiKey, $apiEndpoint, $apiVersion, false);
+    	parent::__construct($apiKey, $apiEndpoint, $apiVersion, $ssl);
     }
 
     /**

--- a/src/Storyblok/ManagementClient.php
+++ b/src/Storyblok/ManagementClient.php
@@ -30,7 +30,7 @@ class ManagementClient extends BaseClient
      *
      * @return \stdClass
      */
-    public function responseHandler($responseObj)
+    public function responseHandler($responseObj, $queryString = null)
     {
         $httpResponseCode = $responseObj->getStatusCode();
         $data = (string) $responseObj->getBody();


### PR DESCRIPTION
This PR adds the SSL parameter to the constructor of the MAPI and it fixes an error caused by the inconsistency of the args of the `responseHandler` function of the MAPI with the one declared in the parent class. This solves #40 and #39.

### How to test it
Since we don't have any test in place for the MAPI, you can manually test this in a standalone PHP script. You can create a new space for testing and use one of the examples from the MAPI:
```
$client = new \Storyblok\ManagementClient('YOUR_OAUTH_TOKEN');
$spaceId = 'SPACE_ID'; // The space id
$storyId = 'STORY_ID'; // The id of the Home story created by default in the test space
$payload = [
  "story" =>  [
    "name" =>  "Story Name",
    "slug" =>  "story-name",
    "id" =>  $storyId ,
    "content" =>  [
      "component" =>  "page",
      "body" =>  []
    ]
  ],
  "force_update" =>  1,
  "publish" =>  1
];

echo $client->put("spaces/{$spaceId}/stories/{$storyId}", $payload)->getCode();
```
If the code is 200 and the story has now the new name and slug assigned via API, it's ok.