### PR TITLE
Always send language options

### DIFF
--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -366,16 +366,14 @@ class Client extends BaseClient
             if ($this->release) {
                 $options['from_release'] = $this->release;
             }
-            
-            if($byUuid) {
-                if ($this->language) {
-                    $options['language'] = $this->language;
-                }
-
-                if ($this->fallbackLanguage) {
-                    $options['fallback_lang'] = $this->fallbackLanguage;
-                }
+                        
+            if ($this->language) {
+                $options['language'] = $this->language;
             }
+
+            if ($this->fallbackLanguage) {
+                $options['fallback_lang'] = $this->fallbackLanguage;
+            }            
 
             try {
                 $response = $this->get($key, $options);


### PR DESCRIPTION
Possible fix for #44.  Remove uuid check.

I removed the check for uuid so that the language option will be send.

btw... would be nice if there would be PHPUnit tests for the library.