### PR TITLE
Fix/54 reset cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - feature/**
+      - fix/**
   pull_request:
     branches: [ master ]
 

--- a/src/Storyblok/ManagementClient.php
+++ b/src/Storyblok/ManagementClient.php
@@ -20,10 +20,6 @@ class ManagementClient extends BaseClient
         parent::__construct($apiKey, $apiEndpoint, $apiVersion, $ssl);
     }
 
-    /**
-     * @param \Psr\Http\Message\ResponseInterface $responseObj
-     * @param null|mixed                          $queryString
-     */
     public function responseHandler($responseObj, $queryString = null): Response
     {
         return parent::responseHandler($responseObj, $queryString);

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -10,6 +10,15 @@ test('Integration: get space', function () {
     $this->assertEquals('40101', $space->httpResponseBody['space']['id']);
 })->group('integration');
 
+test('Integration: get links', function () {
+    $client = new Client('Iw3XKcJb6MwkdZEwoQ9BCQtt');
+    $client->editMode(false);
+    $links = $client->get('links', $client->getApiParameters());
+    $this->assertArrayHasKey('links', $links->httpResponseBody);
+    $this->assertCount(11, $links->httpResponseBody['links']);
+    $this->assertEquals('40101', $links->httpResponseBody['links']['id']);
+})->group('integration');
+
 test('Integration: get All stories', function () {
     $client = new Client('Iw3XKcJb6MwkdZEwoQ9BCQtt');
     $options = $client->getApiParameters();
@@ -34,20 +43,6 @@ test('Integration: get All responses stories', function () {
 })->group('integration');
 
 // useful for testing and reproduce the issue: https://github.com/storyblok/php-client/issues/54
-/*
-test('Integration: get one story with cache', function () {
-    $client = new Client('Iw3XKcJb6MwkdZEwoQ9BCQtt');
-    $options = $client->getApiParameters();
-    $client->setCache('filesystem', ['path' => 'cache']);
-    $_GET['_storyblok_published'] = 129972584;
-    $responses = $client->getStoryBySlug('home');
-    $body = $responses->getBody();
-    $this->assertArrayHasKey('story', $body);
-    $this->assertArrayHasKey('name', $body['story']);
-    $this->assertEquals('home', $body['story']['name']);
-})->group('integration');
-*/
-
 test('Integration: get one story with _storyblok_published', function () {
     $client = new Client('Iw3XKcJb6MwkdZEwoQ9BCQtt');
     $options = $client->getApiParameters();
@@ -64,4 +59,48 @@ test('Integration: get All responses stories with default pagination', function 
     $options = $client->getApiParameters();
     $responses = $client->getAll('stories/', $options, true);
     $this->assertCount(1, $responses);
+})->group('integration');
+
+test('Integration: get one story with option with cache', function () {
+    unset($_GET['_storyblok_published']);
+    $client = new Client('Iw3XKcJb6MwkdZEwoQ9BCQtt');
+    $client->setCache('filesystem', ['path' => 'cache']);
+    $slug = 'home';
+    $key = 'stories/' . $slug;
+    $cacheKey = hash('sha256', $key);
+    $cachedItem = $client->getCachedItem($cacheKey);
+    expect($cachedItem->isHit())->toBeBool()->toBeFalse();
+    $options = $client->getApiParameters();
+    $client->resolveLinks('url');
+    $responses = $client->getStoryBySlug($slug);
+    $body = $responses->getBody();
+    $cv = $responses->getCacheVersion();
+    $this->assertArrayHasKey('story', $body);
+    $this->assertArrayHasKey('name', $body['story']);
+    $this->assertEquals('home', $body['story']['name']);
+    $this->assertArrayHasKey('cv', $body);
+    expect($body['cv'])->toBeNumeric();
+    expect($cv)->toBeNumeric();
+    $key = 'stories/' . $slug;
+    $cacheKey = hash('sha256', $key);
+    $cachedItem = $client->getCachedItem($cacheKey);
+    expect($cachedItem->isHit())->toBeBool()->toBeTrue();
+    $cv1 = $responses->getBody()['cv'];
+    $client2 = new Client('Iw3XKcJb6MwkdZEwoQ9BCQtt');
+    $client2->setCache('filesystem', ['path' => 'cache']);
+    $responses2 = $client2->getStoryBySlug($slug);
+    $cv2 = $responses2->getBody()['cv'];
+    expect($cv1)->toEqual($cv2);
+    $identifier2 = $responses2->getHeaders()['X-Request-Id'];
+    $identifier1 = $responses->getHeaders()['X-Request-Id'];
+    expect($identifier1[0])->toEqual($identifier2[0]);
+    $_GET['_storyblok_published'] = 129972584;
+    $client3 = new Client('Iw3XKcJb6MwkdZEwoQ9BCQtt');
+    $client3->setCache('filesystem', ['path' => 'cache']);
+    $responses3 = $client3->getStoryBySlug($slug);
+    $cv3 = $responses3->getBody()['cv'];
+    expect($cv1)->toEqual($cv3);
+    $identifier3 = $responses3->getHeaders()['X-Request-Id'];
+    $identifier1 = $responses->getHeaders()['X-Request-Id'];
+    expect($identifier1[0])->not()->toEqual($identifier3[0]);
 })->group('integration');

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -16,7 +16,6 @@ test('Integration: get links', function () {
     $links = $client->get('links', $client->getApiParameters());
     $this->assertArrayHasKey('links', $links->httpResponseBody);
     $this->assertCount(11, $links->httpResponseBody['links']);
-    $this->assertEquals('40101', $links->httpResponseBody['links']['id']);
 })->group('integration');
 
 test('Integration: get All stories', function () {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type


- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

Fix issue #54 

## How to test this PR

Run tests `composer run test`
The test is Integration: get one story with the option with cache

## What is the new behavior?

The previous code: in the case of caching and published story, before to call perform a call, try to call the API to retrieve the CV. This last call recalls itself again to retrieve the CV (loop).
The current behavior is: in the case of published stories, it retrieves the data without CV and, after that, stores in the cache the data and the new cv.