### PR TITLE
Fix/avoid array cast

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - feature/**
+      - fix/**
   pull_request:
     branches: [ master ]
 

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -706,7 +706,7 @@ class Client extends BaseClient
     /**
      * Enrich the Stories with resolved links and stories.
      *
-     * @param array|string|\stdClass $data
+     * @param array|\stdClass|string $data
      *
      * @return array|string
      */
@@ -720,7 +720,7 @@ class Client extends BaseClient
                 foreach ($data as $fieldName => $fieldValue) {
                     $enrichedContent[$fieldName] = $this->insertRelations($data['component'], $fieldName, $fieldValue);
                     $enrichedContent[$fieldName] = $this->insertLinks($enrichedContent[$fieldName]);
-                    $enrichedContent[$fieldName] = $this->enrichContent( $enrichedContent[$fieldName]);
+                    $enrichedContent[$fieldName] = $this->enrichContent($enrichedContent[$fieldName]);
                 }
             }
         } elseif (\is_array($data)) {

--- a/src/Storyblok/Client.php
+++ b/src/Storyblok/Client.php
@@ -706,7 +706,7 @@ class Client extends BaseClient
     /**
      * Enrich the Stories with resolved links and stories.
      *
-     * @param array|string $data
+     * @param array|string|\stdClass $data
      *
      * @return array|string
      */
@@ -720,7 +720,7 @@ class Client extends BaseClient
                 foreach ($data as $fieldName => $fieldValue) {
                     $enrichedContent[$fieldName] = $this->insertRelations($data['component'], $fieldName, $fieldValue);
                     $enrichedContent[$fieldName] = $this->insertLinks($enrichedContent[$fieldName]);
-                    $enrichedContent[$fieldName] = $this->enrichContent((array) $enrichedContent[$fieldName]);
+                    $enrichedContent[$fieldName] = $this->enrichContent( $enrichedContent[$fieldName]);
                 }
             }
         } elseif (\is_array($data)) {

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -65,3 +65,28 @@ test('Integration: get All responses stories with default pagination', function 
     $responses = $client->getAll('stories/', $options, true);
     $this->assertCount(1, $responses);
 })->group('integration');
+
+test('Integration: check casting after enriching content', function () {
+    $client = new Client('Iw3XKcJb6MwkdZEwoQ9BCQtt');
+    $client->editMode();
+    $options = $client->getApiParameters();
+    $response = $client->getStoryBySlug("home");
+    $body = $response->getBody();
+    expect($body)->toBeArray()
+    ->toHaveKey("story")
+        ->toHaveCount(4);
+    $story = $body["story"];
+    expect($story)->toBeArray()
+        ->toHaveKey("content")
+        ->toHaveCount(22);
+    $content = $story["content"];
+    expect($content)->toBeArray()
+        ->toHaveKey("_uid")
+        ->toHaveKey("body")
+        ->toHaveKey("component")
+        ->toHaveCount(4);
+    expect($content["_uid"])->toBeString();
+    expect($content["component"])->toBeString();
+
+
+})->group('integration');

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -70,23 +70,24 @@ test('Integration: check casting after enriching content', function () {
     $client = new Client('Iw3XKcJb6MwkdZEwoQ9BCQtt');
     $client->editMode();
     $options = $client->getApiParameters();
-    $response = $client->getStoryBySlug("home");
+    $response = $client->getStoryBySlug('home');
     $body = $response->getBody();
     expect($body)->toBeArray()
-    ->toHaveKey("story")
-        ->toHaveCount(4);
-    $story = $body["story"];
+        ->toHaveKey('story')
+        ->toHaveCount(4)
+    ;
+    $story = $body['story'];
     expect($story)->toBeArray()
-        ->toHaveKey("content")
-        ->toHaveCount(22);
-    $content = $story["content"];
+        ->toHaveKey('content')
+        ->toHaveCount(22)
+    ;
+    $content = $story['content'];
     expect($content)->toBeArray()
-        ->toHaveKey("_uid")
-        ->toHaveKey("body")
-        ->toHaveKey("component")
-        ->toHaveCount(4);
-    expect($content["_uid"])->toBeString();
-    expect($content["component"])->toBeString();
-
-
+        ->toHaveKey('_uid')
+        ->toHaveKey('body')
+        ->toHaveKey('component')
+        ->toHaveCount(4)
+    ;
+    expect($content['_uid'])->toBeString();
+    expect($content['component'])->toBeString();
 })->group('integration');

--- a/tests/Storyblok/Integration/ClientTest.php
+++ b/tests/Storyblok/Integration/ClientTest.php
@@ -128,5 +128,4 @@ test('Integration: get one story with option with cache', function () {
     $identifier3 = $responses3->getHeaders()['X-Request-Id'];
     $identifier1 = $responses->getHeaders()['X-Request-Id'];
     expect($identifier1[0])->not()->toEqual($identifier3[0]);
-
 })->group('integration');


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- If it's an internal request, please add the Jira link. -->
Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Created a test case Integration: check casting after enriching content in tests/Storyblok/Integration/ClientTest.php

## What is the new behavior?

While enrich content is called, a cast was added to the array also for scalar fields. The side effect is that for _uid and component field, the string was cast as an array with one string element.



## Other information